### PR TITLE
[Feature] Per-head-per-layer kviindices support for BatchAttention

### DIFF
--- a/csrc/batch_attention.cu
+++ b/csrc/batch_attention.cu
@@ -68,8 +68,7 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
                             at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o, 
                             at::Tensor layer_idx, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
-                            int64_t page_size, int64_t num_layers,
-                            double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS) {
+                            int64_t page_size, double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS) {
   HolisticPlanInfo<2> plan_info;
   plan_info.FromVector(tensor_to_vec(plan_info_vec));
 

--- a/csrc/batch_attention.cu
+++ b/csrc/batch_attention.cu
@@ -65,10 +65,10 @@ at::Tensor BatchPagedAttentionPlan(at::Tensor float_workspace_buffer,
 
 void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                             at::Tensor plan_info_vec, at::Tensor q, at::Tensor k_cache,
-                            at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o,
-                            std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
+                            at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o, 
+                            at::Tensor layer_idx, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
-                            int64_t page_size,
+                            int64_t page_size, int64_t num_layers,
                             double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS) {
   HolisticPlanInfo<2> plan_info;
   plan_info.FromVector(tensor_to_vec(plan_info_vec));
@@ -103,6 +103,9 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
     v_stride_h = v_cache.stride(1);
     v_stride_n = v_cache.stride(2);
   }
+
+  //NOTE(brian1009): For assigning kv_indices loading
+  unsigned int kv_indices_stride = kv_indices.stride(0);
 
   const c10::cuda::OptionalCUDAGuard device_guard(device);
   const cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
@@ -172,6 +175,9 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
 
           params[i].sm_scale = sm_scale;
 
+          //NOTE(brian1009): For assigting kv_indices loading
+          params[i].layer_idx = static_cast<int*>(layer_idx.data_ptr());
+          params[i].kv_indices_stride = kv_indices_stride;
           ADDITIONAL_PARAMS_SETTER
           PROFILER_PARAMS_SETTER
         }

--- a/csrc/batch_attention_customize_config.jinja
+++ b/csrc/batch_attention_customize_config.jinja
@@ -95,6 +95,11 @@ struct PersistentParams {
   uint32_t v_stride_h;
   uint32_t v_stride_n;
 
+
+  // NOTE(brian1009): for multi-layer planning
+  uint32_t kv_indices_stride;
+  IdType* layer_idx;
+
   float sm_scale;
 
   {{ additional_params_decl }}

--- a/csrc/batch_attention_jit_pybind.cu
+++ b/csrc/batch_attention_jit_pybind.cu
@@ -28,8 +28,7 @@ void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_wo
                             at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o,
                             at::Tensor layer_idx, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
-                            int64_t page_size, int64_t num_layers,
-                            double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS);
+                            int64_t page_size, double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {
   m.def("plan", &BatchPagedAttentionPlan);

--- a/csrc/batch_attention_jit_pybind.cu
+++ b/csrc/batch_attention_jit_pybind.cu
@@ -26,9 +26,9 @@ at::Tensor BatchPagedAttentionPlan(at::Tensor float_workspace_buffer,
 void BatchPagedAttentionRun(at::Tensor float_workspace_buffer, at::Tensor int_workspace_buffer,
                             at::Tensor plan_info_vec, at::Tensor q, at::Tensor k_cache,
                             at::Tensor v_cache, at::Tensor kv_indices, at::Tensor o,
-                            std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
+                            at::Tensor layer_idx, std::optional<at::Tensor> maybe_lse, int64_t mask_mode_code,
                             int64_t layout_code, int64_t num_qo_heads, int64_t num_kv_heads,
-                            int64_t page_size,
+                            int64_t page_size, int64_t num_layers,
                             double sm_scale ADDITIONAL_FUNC_PARAMS PROFILER_FUNC_PARAMS);
 
 TORCH_LIBRARY_FRAGMENT(TORCH_EXTENSION_NAME, m) {

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -24,7 +24,10 @@ from . import jit as jit
 from .activation import gelu_and_mul as gelu_and_mul
 from .activation import gelu_tanh_and_mul as gelu_tanh_and_mul
 from .activation import silu_and_mul as silu_and_mul
-from .attention import BatchAttention as BatchAttention
+from .attention import (
+    BatchAttention as BatchAttention,
+    BatchAttentionWithPerHeadSelectPagedKVCacheWrapper as BatchAttentionWithPerHeadSelectPagedKVCacheWrapper,
+)
 from .cascade import (
     BatchDecodeWithSharedPrefixPagedKVCacheWrapper as BatchDecodeWithSharedPrefixPagedKVCacheWrapper,
 )

--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -67,7 +67,7 @@ class BatchAttention:
         self,
         qo_indptr: torch.Tensor,
         kv_indptr: torch.Tensor,
-        kv_indices: torch.Tensor, # (num_layers, total_kv_indices)
+        kv_indices: torch.Tensor, # (num_layers, total_kv_indices) or (total_kv_indices)
         kv_len_arr: torch.Tensor,
         num_qo_heads: int,
         num_kv_heads: int,
@@ -116,8 +116,10 @@ class BatchAttention:
 
         #NOTE(brian1009): For assisting kv_indices loading.
         #IMPORTANT!!!!!!!!!!!!!!
-        #The user should make sure that the layer_idx should not exceed self._kv_indices.shape[0].
+        #If kv_indices is a 2D tensor, the user should make sure that the layer_idx should not exceed self._kv_indices.shape[0].
         #If the layer_idx exceeds self._kv_indices.shape[0], the behavior is undefined.
+        #If kv_indices is a 1D tensor, the user should make sure that the layer_idx should not exceed self._kv_indices.shape[0].
+        #Then make sure that the layer_idx is always 0.
         self._layer_idx = layer_idx
         # If set, the self._layer_idx will be in-place added by one after each call of run()
         self._add_layer_idx_by_one_after_run = add_layer_idx_by_one_after_run

--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -29,6 +29,8 @@ from .utils import (
     _unpack_paged_kv_cache,
 )
 
+from .triton.batch_attn_utils import augment_head_major_triton
+
 
 @functools.cache
 def get_holistic_attention_module(*args):
@@ -73,12 +75,13 @@ class BatchAttention:
         head_dim_vo: int,
         page_size: int,
         num_layers: int,
-        layer_idx: torch.Tensor,
+        layer_idx: torch.Tensor, # a 0-D tensors, buffer for deciding which layers of per-head kv indices to use
         causal: bool = False,
         sm_scale: float = None,
         q_data_type: torch.dtype = torch.bfloat16,
         kv_data_type: torch.dtype = torch.bfloat16,
         use_profiler: bool = False,
+        add_layer_idx_by_one_after_run: bool = False,
     ) -> None:
         # get jit module
         get_module_args = (
@@ -112,9 +115,14 @@ class BatchAttention:
         # Allocate outside FlashInfer
         self._kv_indices = kv_indices
 
-        #NOTE(brian1009): For assisting kv_indices loading
+        #NOTE(brian1009): For assisting kv_indices loading.
+        #IMPORTANT!!!!!!!!!!!!!!
+        #The user should make sure that the layer_idx should not exceed num_layers.
+        #If the layer_idx exceeds num_layers, the behavior is undefined.
         self._layer_idx = layer_idx
         self._num_layers = num_layers
+        # If set, the self._layer_idx will be in-place added by one after each call of run()
+        self._add_layer_idx_by_one_after_run = add_layer_idx_by_one_after_run
 
         self._plan_info = self.module.plan(
             self.float_workspace_buffer,
@@ -143,6 +151,7 @@ class BatchAttention:
                 raise ValueError(
                     "Profiler is enabled, profiler_buffer must be provided"
                 )
+        
         k_cache, v_cache = _unpack_paged_kv_cache(kv_cache, self._kv_layout)
         if out is None:
             out = torch.empty_like(q)
@@ -178,4 +187,209 @@ class BatchAttention:
             *profiler_args,
         )
 
+        if self._add_layer_idx_by_one_after_run:
+            # inplace adding one.
+            self._layer_idx.add_(1)
+
         return out, lse
+
+
+
+class BatchAttentionWithPerHeadSelectPagedKVCacheWrapper:
+    """
+    FlashInfer wrapper for BatchAttention with per-layer-per-head KV selection.
+    
+    This wrapper extends FlashInfer's BatchAttention to enable different KV token 
+    selection patterns for each KV head during attention operations.
+    """
+    
+    def __init__(self, kv_layout: str = "NHD", device: str = "cuda"):
+        """
+        Initialize the per-head KV cache batch attention wrapper.
+        
+        Args:
+            kv_layout: Layout for KV cache ("NHD" or "HND")
+            device: Device to run on
+        """
+        self.device = torch.device(device)
+        self.wrapper = BatchAttention(kv_layout=kv_layout)
+    
+    def plan(
+        self,
+        qo_indptr: torch.Tensor,                          # (batch_size + 1,) query token boundaries
+        kv_indptr: torch.Tensor,                          # (batch_size + 1,) KV token boundaries
+        all_layers_per_head_kv_indices: torch.Tensor,     # (num_layers, num_kv_heads, total_kv_indices) 
+        seq_lens: torch.Tensor,                           # (batch_size,) sequence lengths
+        num_qo_heads: int,
+        num_kv_heads: int, 
+        head_dim_qk: int,
+        head_dim_vo: int,
+        layer_idx: torch.Tensor,                          # a 0-D tensors, buffer for deciding which layers of per-head kv indices to use
+        num_layers: int,
+        page_block_size: int = 1,
+        causal: bool = True,
+        q_data_type: torch.dtype = torch.bfloat16,
+        kv_data_type: torch.dtype = torch.bfloat16,
+        use_triton: bool = True,
+        add_layer_idx_by_one_after_run: bool = True,
+    ):
+        """
+        Plan batch attention execution with per-KV-head token selection.
+        
+        Transform structure:
+        - Original: batch_size requests with variable query tokens
+        - Virtual: (batch_size × num_kv_heads) virtual batches
+        - Each group of num_kv_heads virtual batches shares the same queries
+        
+        Args:
+            qo_indptr: Query/output token boundaries for each request (batch_size + 1,)
+            kv_indptr: KV token boundaries shared across all heads (batch_size + 1,)
+            per_head_kv_indices: Indices for each head (num_kv_heads, total_kv_indices)
+            seq_lens: Sequence lengths for each request (batch_size,)
+            causal: Whether to use causal attention mask
+            use_triton: Whether to use Triton kernel for performance
+        """
+        batch_size = qo_indptr.shape[0] - 1
+        gqa_group_size = num_qo_heads // num_kv_heads
+        
+        # =====================================================================================
+        # PHASE 1: Transform qo_indptr for Virtual Batches
+        # =====================================================================================
+        # Same as prefill wrapper - replicate query boundaries for each head
+        qo_lengths = qo_indptr[1:] - qo_indptr[:-1]  # (batch_size,)
+        
+        # Build virtual qo_indptr in head-major order
+        qo_lengths_repeated = qo_lengths.repeat(num_kv_heads)
+        virtual_qo_indptr = torch.zeros(batch_size * num_kv_heads + 1, device=self.device, dtype=torch.int32)
+        virtual_qo_indptr[1:] = qo_lengths_repeated
+        torch.cumsum(virtual_qo_indptr, dim=0, out=virtual_qo_indptr)
+        
+        # =====================================================================================
+        # PHASE 2: Transform KV Indices (Head-Major Order)
+        # =====================================================================================
+        # Calculate output offsets for head-major organization
+        kv_batch_lengths = kv_indptr[1:] - kv_indptr[:-1]  # (batch_size,)
+        
+        # Create output_offsets for head-major organization
+        kv_batch_lengths_repeated = kv_batch_lengths.repeat(num_kv_heads)
+        output_offsets = torch.zeros(batch_size * num_kv_heads + 1, device=self.device, dtype=torch.int32)
+        output_offsets[1:] = kv_batch_lengths_repeated
+        torch.cumsum(output_offsets, dim=0, out=output_offsets)
+        
+        # Apply augmentation: block_idx * num_kv_heads + head_idx
+        if use_triton:
+            # Triton kernel for head-major augmentation (handles 3D tensors)
+            try:
+                augmented_indices = augment_head_major_triton(
+                    per_head_kv_indices=all_layers_per_head_kv_indices,
+                    kv_indptr=kv_indptr,
+                    output_offsets=output_offsets,
+                    device=str(self.device)
+                )
+            except (ImportError, RuntimeError):
+                # Fallback to PyTorch if Triton kernel not available
+                use_triton = False
+        
+        if not use_triton:
+            # Optimized PyTorch implementation - process all layers at once
+            head_offsets = torch.arange(num_kv_heads, device=self.device, dtype=all_layers_per_head_kv_indices.dtype)
+            # Broadcast head_offsets to match 3D tensor shape
+            # per_head_kv_indices: (num_layers, num_kv_heads, total_kv_indices)
+            # head_offsets: (num_kv_heads,) -> (1, num_kv_heads, 1)
+            augmented_per_head = all_layers_per_head_kv_indices * num_kv_heads + head_offsets.unsqueeze(0).unsqueeze(2)
+            
+            # Flatten the last two dimensions for each layer
+            # Result: (num_layers, num_kv_heads * total_kv_indices)
+            augmented_indices = augmented_per_head.flatten(start_dim=1)
+        
+        # =====================================================================================
+        # PHASE 3: Transform seq_lens for Virtual Batches
+        # =====================================================================================
+        # Replicate seq_lens for each head in head-major order
+        # Original: [seq_len_0, seq_len_1, ...]
+        # Virtual: [seq_len_0, seq_len_1, ..., seq_len_0, seq_len_1, ..., ...]
+        #          ^--------head 0---------^  ^--------head 1---------^
+        virtual_seq_lens = seq_lens.repeat(num_kv_heads)
+        
+        # =====================================================================================
+        # PHASE 4: FlashInfer Planning
+        # =====================================================================================
+        # Plan underlying FlashInfer wrapper with transformed data
+        self.wrapper.plan(
+            virtual_qo_indptr,      # Transformed query boundaries
+            output_offsets,         # Virtual KV batch boundaries (augmented_indptr)
+            augmented_indices,      # Augmented and interleaved KV indices
+            virtual_seq_lens,       # Replicated sequence lengths for virtual batches
+            gqa_group_size,         # num_qo_heads per virtual batch
+            1,                      # num_kv_heads=1 since we unrolled
+            head_dim_qk,               # head dimension
+            head_dim_vo,               # head dimension for values
+            page_block_size,
+            num_layers=num_layers,
+            layer_idx=layer_idx,
+            causal=causal,
+            q_data_type=q_data_type, 
+            kv_data_type=kv_data_type,
+            add_layer_idx_by_one_after_run=add_layer_idx_by_one_after_run,
+        )
+    
+    def run(
+        self,
+        query: torch.Tensor,  # (total_query_tokens, num_qo_heads, head_dim)
+        paged_kv_cache: Tuple[torch.Tensor, torch.Tensor],  # KV cache tuple
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Run batch attention with per-KV-head token selection.
+        
+        Args:
+            query: Query tensor (total_query_tokens, num_qo_heads, head_dim)
+            paged_kv_cache: Tuple of (key, value) tensors
+            
+        Returns:
+            output: Attention output (total_query_tokens, num_qo_heads, head_dim)
+            lse: Log-sum-exp values
+        """
+        key, value = paged_kv_cache
+        total_query_tokens, num_qo_heads, head_dim = query.shape
+        total_blocks, page_block_size, num_kv_heads, _ = key.shape
+        gqa_group_size = num_qo_heads // num_kv_heads
+        
+        # =====================================================================================
+        # PHASE 1: Reshape KV Cache (Same as Prefill)
+        # =====================================================================================
+        # Use interleaved layout for KV cache
+        key_reshaped = key.view(total_blocks * num_kv_heads, page_block_size, 1, head_dim)
+        value_reshaped = value.view(total_blocks * num_kv_heads, page_block_size, 1, head_dim)
+        
+        # =====================================================================================
+        # PHASE 2: Query Transformation to Head-Major Layout
+        # =====================================================================================
+        # Same transformation as prefill wrapper
+        query_reshaped = query.view(total_query_tokens, num_kv_heads, gqa_group_size, head_dim)
+        query_permuted = query_reshaped.permute(1, 0, 2, 3).contiguous()  # (num_kv_heads, total_tokens, gqa_group_size, head_dim)
+        query_for_flashinfer = query_permuted.reshape(-1, gqa_group_size, head_dim)
+        
+        # =====================================================================================
+        # PHASE 3: Run Attention
+        # =====================================================================================
+        # BatchAttention.run() returns (output, lse) directly
+        output, lse = self.wrapper.run(query_for_flashinfer, (key_reshaped, value_reshaped))
+        
+        # =====================================================================================
+        # PHASE 4: Reshape Output Back
+        # =====================================================================================
+        # Reverse transformation
+        # (num_kv_heads * total_tokens, gqa_group_size, head_dim) ->
+        # (num_kv_heads, total_tokens, gqa_group_size, head_dim)
+        output_reshaped = output.view(num_kv_heads, total_query_tokens, gqa_group_size, head_dim)
+        # Permute back: (total_tokens, num_kv_heads, gqa_group_size, head_dim)
+        output_permuted = output_reshaped.permute(1, 0, 2, 3).contiguous()
+        # Reshape to final format: (total_tokens, num_qo_heads, head_dim)
+        output_final = output_permuted.reshape(total_query_tokens, num_qo_heads, head_dim)
+        
+        # Similar for LSE
+        lse_reshaped = lse.view(num_kv_heads, total_query_tokens, gqa_group_size)
+        lse_permuted = lse_reshaped.permute(1, 0, 2).contiguous()
+        lse_final = lse_permuted.reshape(total_query_tokens, num_qo_heads)
+        
+        return output_final, lse_final

--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -398,6 +398,6 @@ class BatchAttentionWithPerHeadSelectPagedKVCacheWrapper:
             kv_heads=num_kv_heads,
             tokens=total_query_tokens,
             group_size=gqa_group_size
-        )
+        ).contiguous()
         
         return output_final, lse_final

--- a/flashinfer/attention.py
+++ b/flashinfer/attention.py
@@ -280,8 +280,6 @@ class BatchAttentionWithPerHeadSelectPagedKVCacheWrapper:
             try:
                 augmented_indices = augment_head_major_triton(
                     per_head_kv_indices=all_layers_per_head_kv_indices,
-                    kv_indptr=kv_indptr,
-                    output_offsets=output_offsets,
                     device=str(self.device)
                 )
             except (ImportError, RuntimeError):

--- a/flashinfer/triton/batch_attn_utils.py
+++ b/flashinfer/triton/batch_attn_utils.py
@@ -1,0 +1,105 @@
+import torch
+import triton
+from .kernels.batch_attn_utils import _augment_head_major_kernel
+
+def augment_head_major_triton_3d(
+    per_head_kv_indices: torch.Tensor,  # (num_layers, num_kv_heads, total_indices)
+    device: str = "cuda"
+) -> torch.Tensor:
+    """
+    Triton-accelerated head-major augmentation for 3D tensors.
+    
+    This function augments indices for head-major virtual batch organization
+    across multiple layers in parallel.
+    
+    Args:
+        per_head_kv_indices: Input indices for each layer and head 
+                           (num_layers, num_kv_heads, total_indices)
+        device: Device to run on
+        
+    Returns:
+        Augmented indices (num_layers, num_kv_heads * total_indices)
+    """
+    num_layers, num_kv_heads, total_indices = per_head_kv_indices.shape
+    
+    # Allocate output tensor
+    output_indices = torch.empty(
+        (num_layers, num_kv_heads * total_indices),
+        dtype=per_head_kv_indices.dtype,
+        device=device
+    )
+    
+    # Configure kernel launch parameters
+    BLOCK_SIZE = 1024
+    total_size_per_layer = num_kv_heads * total_indices
+    num_blocks_per_layer = triton.cdiv(total_size_per_layer, BLOCK_SIZE)
+    
+    # Launch kernel with 2D grid: (num_layers, num_blocks_per_layer)
+    _augment_head_major_3d_kernel[(num_layers, num_blocks_per_layer)](
+        per_head_kv_indices,
+        output_indices,
+        num_layers,
+        num_kv_heads,
+        total_indices,
+        BLOCK_SIZE=BLOCK_SIZE
+    )
+    
+    return output_indices
+
+
+def augment_head_major_triton(
+    per_head_kv_indices: torch.Tensor,  # (num_kv_heads, total_indices) or (num_layers, num_kv_heads, total_indices)
+    kv_indptr: torch.Tensor,            # Not used in this kernel, kept for API compatibility
+    output_offsets: torch.Tensor,       # Not used in this kernel, kept for API compatibility
+    device: str = "cuda"
+) -> torch.Tensor:
+    """
+    Triton-accelerated head-major augmentation.
+    
+    This function augments indices for head-major virtual batch organization.
+    The output is directly in head-major order, no interleaving needed.
+    
+    Automatically handles both 2D and 3D input tensors.
+    
+    Args:
+        per_head_kv_indices: Input indices for each head 
+                           - 2D: (num_kv_heads, total_indices)
+                           - 3D: (num_layers, num_kv_heads, total_indices)
+        kv_indptr: Batch boundaries (kept for API compatibility, not used)
+        output_offsets: Virtual batch offsets (kept for API compatibility, not used)
+        device: Device to run on
+        
+    Returns:
+        Augmented indices in head-major order
+        - 2D input: (num_kv_heads * total_indices,) flattened
+        - 3D input: (num_layers, num_kv_heads * total_indices)
+    """
+    # Check if input is 3D
+    if per_head_kv_indices.dim() == 3:
+        return augment_head_major_triton_3d(per_head_kv_indices, device)
+    
+    # Original 2D implementation
+    num_kv_heads, total_indices = per_head_kv_indices.shape
+    
+    # Allocate output tensor
+    output_indices = torch.empty(
+        num_kv_heads * total_indices,
+        dtype=per_head_kv_indices.dtype,
+        device=device
+    )
+    
+    # Configure kernel launch parameters
+    BLOCK_SIZE = 1024  # Larger block size for better performance
+    total_size = num_kv_heads * total_indices
+    num_blocks = triton.cdiv(total_size, BLOCK_SIZE)
+    
+    # Launch kernel
+    _augment_head_major_kernel[(num_blocks,)](
+        per_head_kv_indices,
+        output_indices,
+        num_kv_heads,
+        total_indices,
+        BLOCK_SIZE=BLOCK_SIZE
+    )
+    
+    return output_indices

--- a/flashinfer/triton/batch_attn_utils.py
+++ b/flashinfer/triton/batch_attn_utils.py
@@ -49,8 +49,6 @@ def augment_head_major_triton_3d(
 
 def augment_head_major_triton(
     per_head_kv_indices: torch.Tensor,  # (num_kv_heads, total_indices) or (num_layers, num_kv_heads, total_indices)
-    kv_indptr: torch.Tensor,            # Not used in this kernel, kept for API compatibility
-    output_offsets: torch.Tensor,       # Not used in this kernel, kept for API compatibility
     device: str = "cuda"
 ) -> torch.Tensor:
     """
@@ -65,8 +63,6 @@ def augment_head_major_triton(
         per_head_kv_indices: Input indices for each head 
                            - 2D: (num_kv_heads, total_indices)
                            - 3D: (num_layers, num_kv_heads, total_indices)
-        kv_indptr: Batch boundaries (kept for API compatibility, not used)
-        output_offsets: Virtual batch offsets (kept for API compatibility, not used)
         device: Device to run on
         
     Returns:

--- a/flashinfer/triton/batch_attn_utils.py
+++ b/flashinfer/triton/batch_attn_utils.py
@@ -1,6 +1,6 @@
 import torch
 import triton
-from .kernels.batch_attn_utils import _augment_head_major_kernel
+from .kernels.batch_attn_utils import _augment_head_major_kernel, _augment_head_major_3d_kernel
 
 def augment_head_major_triton_3d(
     per_head_kv_indices: torch.Tensor,  # (num_layers, num_kv_heads, total_indices)

--- a/flashinfer/triton/kernels/batch_attn_utils.py
+++ b/flashinfer/triton/kernels/batch_attn_utils.py
@@ -1,0 +1,112 @@
+"""
+Triton kernel for head-major augmentation (without interleaving).
+
+This kernel performs the augmentation step for head-major virtual batch organization:
+- Augments indices: block_idx * num_kv_heads + head_idx
+- Directly outputs in head-major order (no interleaving needed)
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _augment_head_major_kernel(
+    per_head_kv_indices_ptr,  # (num_kv_heads, total_indices)
+    output_indices_ptr,       # Output augmented indices
+    num_kv_heads,
+    total_indices,
+    BLOCK_SIZE: tl.constexpr
+):
+    """
+    Optimized Triton kernel for head-major augmentation.
+    
+    Each thread block processes a contiguous chunk of the flattened output.
+    The augmentation formula is: augmented_idx = original_idx * num_kv_heads + head_idx
+    """
+    # Get the program ID
+    pid = tl.program_id(0)
+    
+    # Calculate the starting position in the flattened output
+    start_pos = pid * BLOCK_SIZE
+    
+    # Create offsets for this block
+    offsets = start_pos + tl.arange(0, BLOCK_SIZE)
+    
+    # Calculate total size
+    total_size = num_kv_heads * total_indices
+    
+    # Mask for valid positions
+    mask = offsets < total_size
+    
+    # Calculate head index and position within head for each element
+    # Since output is head-major: position = head_idx * total_indices + idx_within_head
+    head_idx = offsets // total_indices
+    idx_within_head = offsets % total_indices
+    
+    # Calculate input positions
+    input_pos = head_idx * total_indices + idx_within_head
+    
+    # Load original indices
+    original_indices = tl.load(per_head_kv_indices_ptr + input_pos, mask=mask, other=0)
+    
+    # Apply augmentation: block_idx * num_kv_heads + head_idx
+    augmented_indices = original_indices * num_kv_heads + head_idx
+    
+    # Store augmented indices
+    tl.store(output_indices_ptr + offsets, augmented_indices, mask=mask)
+
+
+@triton.jit
+def _augment_head_major_3d_kernel(
+    per_head_kv_indices_ptr,  # (num_layers, num_kv_heads, total_indices)
+    output_indices_ptr,       # Output augmented indices (num_layers, num_kv_heads * total_indices)
+    num_layers,
+    num_kv_heads,
+    total_indices,
+    BLOCK_SIZE: tl.constexpr
+):
+    """
+    Optimized Triton kernel for head-major augmentation with 3D input.
+    
+    Processes all layers in parallel.
+    The augmentation formula is: augmented_idx = original_idx * num_kv_heads + head_idx
+    """
+    # Get the program ID (2D grid)
+    pid_layer = tl.program_id(0)
+    pid_block = tl.program_id(1)
+    
+    # Skip if layer index is out of bounds
+    if pid_layer >= num_layers:
+        return
+    
+    # Calculate the starting position within the layer
+    start_pos = pid_block * BLOCK_SIZE
+    
+    # Create offsets for this block
+    offsets = start_pos + tl.arange(0, BLOCK_SIZE)
+    
+    # Calculate total size per layer
+    total_size_per_layer = num_kv_heads * total_indices
+    
+    # Mask for valid positions within the layer
+    mask = offsets < total_size_per_layer
+    
+    # Calculate head index and position within head for each element
+    head_idx = offsets // total_indices
+    idx_within_head = offsets % total_indices
+    
+    # Calculate input positions (3D tensor layout)
+    input_pos = pid_layer * total_size_per_layer + head_idx * total_indices + idx_within_head
+    
+    # Calculate output positions (2D tensor layout)
+    output_pos = pid_layer * total_size_per_layer + offsets
+    
+    # Load original indices
+    original_indices = tl.load(per_head_kv_indices_ptr + input_pos, mask=mask, other=0)
+    
+    # Apply augmentation: block_idx * num_kv_heads + head_idx
+    augmented_indices = original_indices * num_kv_heads + head_idx
+    
+    # Store augmented indices
+    tl.store(output_indices_ptr + output_pos, augmented_indices, mask=mask)

--- a/include/flashinfer/attention/persistent.cuh
+++ b/include/flashinfer/attention/persistent.cuh
@@ -174,7 +174,8 @@ struct BlockBatchPagedAttentionPersistent {
     DTypeQ* q = params.q;
     DTypeKV* k = params.k;
     DTypeKV* v = params.v;
-    IdType* kv_indices = params.kv_indices;
+    const uint32_t kv_indices_stride = params.kv_indices_stride;
+    IdType* kv_indices = params.kv_indices + params.layer_idx[0] * kv_indices_stride;
     float* partial_lse = params.partial_lse;
     IdType* work_indptr = params.work_indptr;
 

--- a/tests/test_batch_attention.py
+++ b/tests/test_batch_attention.py
@@ -142,6 +142,7 @@ def _run_attention(
         head_dim,
         head_dim,
         page_block_size,
+        layer_idx=torch.tensor(0, device=dev),
         causal=causal,
         q_data_type=test_dtype,
         kv_data_type=test_dtype,

--- a/tests/test_per_head_kv_batch_attention.py
+++ b/tests/test_per_head_kv_batch_attention.py
@@ -137,7 +137,6 @@ def test_golden_reference(
         head_dim_qk=head_dim,
         head_dim_vo=head_dim,
         layer_idx=layer_idx_buffer, # a 0-D tensors
-        num_layers=1,
         page_block_size=data['page_block_size'],
         causal=causal,
         q_data_type=dtype,
@@ -180,7 +179,6 @@ def test_golden_reference(
             head_dim,
             head_dim,
             data['page_block_size'],
-            num_layers=1,
             layer_idx=torch.tensor(0, device=device), # a 0-D tensors
             causal=causal,
             q_data_type=dtype,
@@ -233,7 +231,6 @@ def test_golden_reference_with_sparsity(sparsity_ratio, device="cuda"):
         head_dim_qk=head_dim,
         head_dim_vo=head_dim,
         layer_idx=torch.tensor(0, device=device), # a 0-D tensors
-        num_layers=1,
         page_block_size=data['page_block_size'],
         causal=causal,
         q_data_type=dtype,
@@ -270,7 +267,6 @@ def test_golden_reference_with_sparsity(sparsity_ratio, device="cuda"):
             head_dim,
             head_dim,
             data['page_block_size'],
-            num_layers=1,
             layer_idx=torch.tensor(0, device=device), # a 0-D tensors
             causal=causal,
             q_data_type=dtype,
@@ -296,7 +292,7 @@ def test_golden_reference_with_sparsity(sparsity_ratio, device="cuda"):
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("causal", [True])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("num_layers", [2, 3])
+@pytest.mark.parametrize("num_layers", [2, 4, 8, 16, 32])
 def test_per_layer_correctness(
     batch_size, num_kv_heads, num_qo_heads, head_dim, 
     causal, dtype, num_layers, device="cuda"
@@ -330,7 +326,6 @@ def test_per_layer_correctness(
             head_dim_qk=head_dim,
             head_dim_vo=head_dim,
             layer_idx=torch.tensor(0, device=device), # a 0-D tensors
-            num_layers=1,
             page_block_size=data['page_block_size'],
             causal=causal,
             q_data_type=dtype,
@@ -359,7 +354,6 @@ def test_per_layer_correctness(
         head_dim_qk=head_dim,
         head_dim_vo=head_dim,
         layer_idx=layer_idx_buffer, # a 0-D tensors
-        num_layers=num_layers,
         page_block_size=data['page_block_size'],
         causal=causal,
         q_data_type=dtype,
@@ -416,7 +410,6 @@ def test_per_layer_correctness_with_cuda_graph(num_layers, device="cuda"):
         head_dim_qk=head_dim,
         head_dim_vo=head_dim,
         layer_idx=layer_idx_buffer, # a 0-D tensors
-        num_layers=num_layers,
         page_block_size=data['page_block_size'],
         causal=causal,
         q_data_type=dtype,
@@ -448,7 +441,6 @@ def test_per_layer_correctness_with_cuda_graph(num_layers, device="cuda"):
         head_dim_qk=head_dim,
         head_dim_vo=head_dim,
         layer_idx=layer_idx_buffer_cg, # a 0-D tensors
-        num_layers=num_layers,
         page_block_size=data['page_block_size'],
         causal=causal,
         q_data_type=dtype,

--- a/tests/test_per_head_kv_batch_attention.py
+++ b/tests/test_per_head_kv_batch_attention.py
@@ -291,7 +291,7 @@ def test_golden_reference_with_sparsity(sparsity_ratio, device="cuda"):
 ])
 @pytest.mark.parametrize("head_dim", [128])
 @pytest.mark.parametrize("causal", [True])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("num_layers", [2, 4, 8, 16, 32])
 def test_per_layer_correctness(
     batch_size, num_kv_heads, num_qo_heads, head_dim, 

--- a/tests/test_per_head_kv_batch_attention.py
+++ b/tests/test_per_head_kv_batch_attention.py
@@ -106,9 +106,10 @@ def generate_test_data(
     (2048, 128),  # Medium
     (8192, 256),  # Large
 ])
+@pytest.mark.parametrize("use_triton", [True, False])
 def test_golden_reference(
     batch_size, num_kv_heads, num_qo_heads, head_dim, 
-    causal, dtype, max_seq_len, max_q_len, device="cuda"
+    causal, dtype, max_seq_len, max_q_len, use_triton, device="cuda"
 ):
     """Test wrapper against golden reference by running each KV head separately"""
     seed = 42
@@ -141,7 +142,7 @@ def test_golden_reference(
         causal=causal,
         q_data_type=dtype,
         kv_data_type=dtype,
-        use_triton=False,
+        use_triton=use_triton,
         add_layer_idx_by_one_after_run=True
     )
     output_wrapper, lse_wrapper = batch_attention_wrapper.run(

--- a/tests/test_per_head_kv_batch_attention.py
+++ b/tests/test_per_head_kv_batch_attention.py
@@ -1,0 +1,495 @@
+"""
+Pytest for testing BatchAttentionWithPerHeadSelectPagedKVCacheWrapper against golden reference
+"""
+
+import torch
+import numpy as np
+import pytest
+import flashinfer
+
+def generate_test_data(
+    batch_size, num_kv_heads, num_qo_heads, head_dim, 
+    device, dtype, seed, sparsity_ratio=0.5,
+    min_seq_len=100, max_seq_len=500,
+    min_q_len=1, max_q_len=50, num_layers=1
+):
+    """Generate test data for per-head KV selection tests"""
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    
+    # Generate sequence lengths with configurable ranges
+    seq_lens = torch.randint(min_seq_len, max_seq_len, (batch_size,), device=device, dtype=torch.int32)
+    q_lens = torch.randint(min_q_len, max_q_len, (batch_size,), device=device, dtype=torch.int32)
+    
+    # Build indptr arrays
+    qo_indptr = torch.cat([torch.tensor([0], device=device), torch.cumsum(q_lens, dim=0)], dim=0).int()
+    total_query_tokens = qo_indptr[-1].item()
+    
+    # Determine tokens to select per batch
+    selected_tokens_per_batch = []
+    for batch_idx in range(batch_size):
+        seq_len = seq_lens[batch_idx].item()
+        num_selected = max(1, int(seq_len * sparsity_ratio))
+        selected_tokens_per_batch.append(num_selected)
+    
+    kv_indptr = torch.cat([
+        torch.tensor([0], device=device),
+        torch.cumsum(torch.tensor(selected_tokens_per_batch, device=device), dim=0)
+    ], dim=0).int()
+    
+    # Generate per-head KV indices with shuffling
+    all_layers_per_head_kv_indices = []
+    for layer_idx in range(num_layers):
+        per_head_kv_indices = []
+        for head_idx in range(num_kv_heads):
+            head_indices = []
+            for batch_idx in range(batch_size):
+                seq_len = seq_lens[batch_idx].item()
+                num_selected = selected_tokens_per_batch[batch_idx]
+                
+                # Select different random tokens for each head
+                selected_local = torch.randperm(seq_len, device=device)[:num_selected].sort()[0]
+                
+                # Global indices
+                global_offset = sum(seq_lens[:batch_idx].tolist()) if batch_idx > 0 else 0
+                selected_global = selected_local + global_offset
+                
+                head_indices.append(selected_global)
+            
+            head_indices = torch.cat(head_indices)
+            per_head_kv_indices.append(head_indices)
+        
+        per_head_kv_indices = torch.stack(per_head_kv_indices)
+        all_layers_per_head_kv_indices.append(per_head_kv_indices)
+    
+    all_layers_per_head_kv_indices = torch.stack(all_layers_per_head_kv_indices)
+    
+    # Generate tensors
+    query = torch.rand(total_query_tokens, num_qo_heads, head_dim, dtype=dtype, device=device)
+    
+    # Use original (non-sparsified) total tokens for KV cache size
+    original_total_kv_tokens = seq_lens.sum().item()
+    page_block_size = 1
+    key = torch.rand(original_total_kv_tokens, page_block_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+    value = torch.rand(original_total_kv_tokens, page_block_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+    
+    # Compute last_page_len
+    last_page_len = (seq_lens - 1) % page_block_size + 1
+    last_page_len = last_page_len.unsqueeze(1).expand(batch_size, num_kv_heads)
+    
+    sparsified_seq_lens = torch.tensor(selected_tokens_per_batch, device=device, dtype=torch.int32)
+    
+    return {
+        'query': query,
+        'key': key,
+        'value': value,
+        'qo_indptr': qo_indptr,
+        'kv_indptr': kv_indptr,
+        'all_layers_per_head_kv_indices': all_layers_per_head_kv_indices,
+        'seq_lens': seq_lens,
+        'sparsified_seq_lens': sparsified_seq_lens,
+        'last_page_len': last_page_len,
+        'page_block_size': page_block_size,
+    }
+
+
+@pytest.mark.parametrize("batch_size", [1, 4, 8, 16])
+@pytest.mark.parametrize("num_kv_heads,num_qo_heads", [
+    (4, 32),  # 1:8 GQA ratio
+    (8, 32),  # 1:4 GQA ratio
+])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("causal", [True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("max_seq_len,max_q_len", [
+    (500, 50),    # Default
+    (2048, 128),  # Medium
+    (8192, 256),  # Large
+])
+def test_golden_reference(
+    batch_size, num_kv_heads, num_qo_heads, head_dim, 
+    causal, dtype, max_seq_len, max_q_len, device="cuda"
+):
+    """Test wrapper against golden reference by running each KV head separately"""
+    seed = 42
+    
+    # Set min lengths relative to max lengths
+    min_seq_len = max(100, max_seq_len // 10)
+    min_q_len = max(1, max_q_len // 10)
+    
+    data = generate_test_data(
+        batch_size, num_kv_heads, num_qo_heads, head_dim,
+        device, dtype, seed,
+        min_seq_len=min_seq_len, max_seq_len=max_seq_len,
+        min_q_len=min_q_len, max_q_len=max_q_len
+    )
+    
+    # Run BatchAttentionWithPerHeadSelectPagedKVCacheWrapper
+    batch_attention_wrapper = flashinfer.BatchAttentionWithPerHeadSelectPagedKVCacheWrapper(device=device)
+    layer_idx_buffer = torch.tensor([0], device=device)
+    batch_attention_wrapper.plan(
+        qo_indptr=data['qo_indptr'],
+        kv_indptr=data['kv_indptr'],
+        all_layers_per_head_kv_indices=data['all_layers_per_head_kv_indices'].int(), # (num_layers, num_kv_heads, total_kv_indices)
+        seq_lens=data['sparsified_seq_lens'],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        layer_idx=layer_idx_buffer, # a 0-D tensors
+        num_layers=1,
+        page_block_size=data['page_block_size'],
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        use_triton=False,
+        add_layer_idx_by_one_after_run=True
+    )
+    output_wrapper, lse_wrapper = batch_attention_wrapper.run(
+        data['query'], (data['key'], data['value'])
+    )
+    # check whether layer_idx_buffer is updated
+    assert layer_idx_buffer.item() == 1, "layer_idx_buffer should be updated to 1"
+    torch.cuda.synchronize()
+    
+    # Compute golden reference
+    gqa_group_size = num_qo_heads // num_kv_heads
+    golden_outputs = []
+    golden_lses = []
+
+    for kv_head_idx in range(num_kv_heads):
+        # Extract queries for this KV head group
+        query_start = kv_head_idx * gqa_group_size
+        query_end = (kv_head_idx + 1) * gqa_group_size
+        query_per_head = data['query'][:, query_start:query_end, :].contiguous()
+        
+        # Extract KV cache for this head
+        head_kv_indices = data['all_layers_per_head_kv_indices'][0, kv_head_idx] # assuming that num_layers = 1
+        key_per_head = data['key'][:, :, kv_head_idx:kv_head_idx+1, :].contiguous()
+        value_per_head = data['value'][:, :, kv_head_idx:kv_head_idx+1, :].contiguous()
+        
+        # Run standard FlashInfer BatchAttention
+        wrapper = flashinfer.BatchAttention(kv_layout="NHD")
+        wrapper.plan(
+            data['qo_indptr'],
+            data['kv_indptr'],
+            head_kv_indices.int(),
+            data['sparsified_seq_lens'],
+            gqa_group_size,
+            1,
+            head_dim,
+            head_dim,
+            data['page_block_size'],
+            num_layers=1,
+            layer_idx=torch.tensor(0, device=device), # a 0-D tensors
+            causal=causal,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+        )
+        
+        output_per_head, lse_per_head = wrapper.run(query_per_head, (key_per_head, value_per_head))
+        torch.cuda.synchronize()
+        
+        golden_outputs.append(output_per_head)
+        golden_lses.append(lse_per_head)
+    
+    # Concatenate results
+    golden_output = torch.cat(golden_outputs, dim=1)
+    golden_lse = torch.cat(golden_lses, dim=1)
+    
+    # Assert with appropriate tolerances
+    torch.testing.assert_close(output_wrapper, golden_output, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(lse_wrapper, golden_lse, rtol=1e-3, atol=1e-3)
+
+
+# Additional test with custom sequence length ranges
+@pytest.mark.parametrize("sparsity_ratio", [0.25, 0.5, 0.75])
+def test_golden_reference_with_sparsity(sparsity_ratio, device="cuda"):
+    """Test golden reference with different sparsity levels"""
+    batch_size = 4
+    num_kv_heads = 4
+    num_qo_heads = 16
+    head_dim = 128
+    causal = True
+    dtype = torch.bfloat16
+    seed = 42
+    
+    data = generate_test_data(
+        batch_size, num_kv_heads, num_qo_heads, head_dim,
+        device, dtype, seed, sparsity_ratio=sparsity_ratio,
+        min_seq_len=200, max_seq_len=1000,
+        min_q_len=10, max_q_len=100
+    )
+    
+    # Run wrapper
+    batch_attention_wrapper = flashinfer.BatchAttentionWithPerHeadSelectPagedKVCacheWrapper(device=device)
+    batch_attention_wrapper.plan(
+        qo_indptr=data['qo_indptr'],
+        kv_indptr=data['kv_indptr'],
+        all_layers_per_head_kv_indices=data['all_layers_per_head_kv_indices'].int(), # (num_layers, num_kv_heads, total_kv_indices)
+        seq_lens=data['sparsified_seq_lens'],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        layer_idx=torch.tensor(0, device=device), # a 0-D tensors
+        num_layers=1,
+        page_block_size=data['page_block_size'],
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        use_triton=False
+    )
+    
+    output_wrapper, lse_wrapper = batch_attention_wrapper.run(
+        data['query'], (data['key'], data['value'])
+    )
+    
+    # Compute golden reference
+    gqa_group_size = num_qo_heads // num_kv_heads
+    golden_outputs = []
+    golden_lses = []
+    
+    for kv_head_idx in range(num_kv_heads):
+        query_start = kv_head_idx * gqa_group_size
+        query_end = (kv_head_idx + 1) * gqa_group_size
+        query_per_head = data['query'][:, query_start:query_end, :].contiguous()
+        
+        head_kv_indices = data['all_layers_per_head_kv_indices'][0, kv_head_idx] # assuming that num_layers = 1
+        key_per_head = data['key'][:, :, kv_head_idx:kv_head_idx+1, :].contiguous()
+        value_per_head = data['value'][:, :, kv_head_idx:kv_head_idx+1, :].contiguous()
+        
+        wrapper = flashinfer.BatchAttention(kv_layout="NHD")
+        wrapper.plan(
+            data['qo_indptr'],
+            data['kv_indptr'],
+            head_kv_indices.int(),
+            data['sparsified_seq_lens'],
+            gqa_group_size,
+            1,
+            head_dim,
+            head_dim,
+            data['page_block_size'],
+            num_layers=1,
+            layer_idx=torch.tensor(0, device=device), # a 0-D tensors
+            causal=causal,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+        )
+        
+        output_per_head, lse_per_head = wrapper.run(query_per_head, (key_per_head, value_per_head))
+        golden_outputs.append(output_per_head)
+        golden_lses.append(lse_per_head)
+    
+    golden_output = torch.cat(golden_outputs, dim=1)
+    golden_lse = torch.cat(golden_lses, dim=1)
+    
+    torch.testing.assert_close(output_wrapper, golden_output, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(lse_wrapper, golden_lse, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("batch_size", [4, 8, 16])
+@pytest.mark.parametrize("num_kv_heads,num_qo_heads", [
+    (4, 32),  # 1:8 GQA ratio
+    (8, 32),  # 1:4 GQA ratio
+])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("causal", [True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("num_layers", [2, 3])
+def test_per_layer_correctness(
+    batch_size, num_kv_heads, num_qo_heads, head_dim, 
+    causal, dtype, num_layers, device="cuda"
+):
+    """Test whether the layer_idx is correctly updated"""
+    seed = 42
+
+    min_seq_len = 100
+    max_seq_len = 500
+    min_q_len = 1
+    max_q_len = 50
+    data = generate_test_data(
+        batch_size, num_kv_heads, num_qo_heads, head_dim,
+        device, dtype, seed,
+        min_seq_len=min_seq_len, max_seq_len=max_seq_len,
+        min_q_len=min_q_len, max_q_len=max_q_len, num_layers=num_layers
+    )
+
+    # golden, plan every time
+    output_golden, lse_golden = [], []
+    for layer_idx in range(num_layers):
+        batch_attention_wrapper = flashinfer.BatchAttentionWithPerHeadSelectPagedKVCacheWrapper(device=device)
+        per_head_kv_indices = data['all_layers_per_head_kv_indices'][layer_idx]
+        batch_attention_wrapper.plan(
+            qo_indptr=data['qo_indptr'],
+            kv_indptr=data['kv_indptr'],
+            all_layers_per_head_kv_indices=per_head_kv_indices.int(), # (num_layers, num_kv_heads, total_kv_indices)
+            seq_lens=data['sparsified_seq_lens'],
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim_qk=head_dim,
+            head_dim_vo=head_dim,
+            layer_idx=torch.tensor(0, device=device), # a 0-D tensors
+            num_layers=1,
+            page_block_size=data['page_block_size'],
+            causal=causal,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            use_triton=False,
+            add_layer_idx_by_one_after_run=False
+        )
+        output_per_head, lse_per_head = batch_attention_wrapper.run(
+            data['query'], (data['key'], data['value'])
+        )
+        output_golden.append(output_per_head)
+        lse_golden.append(lse_per_head)
+
+    
+    # reference, plan once
+    output_ours, lse_ours = [], []
+    batch_attention_wrapper = flashinfer.BatchAttentionWithPerHeadSelectPagedKVCacheWrapper(device=device)
+    layer_idx_buffer = torch.tensor([0], device=device)
+    batch_attention_wrapper.plan(
+        qo_indptr=data['qo_indptr'],
+        kv_indptr=data['kv_indptr'],
+        all_layers_per_head_kv_indices=data['all_layers_per_head_kv_indices'].int(), # (num_layers, num_kv_heads, total_kv_indices)
+        seq_lens=data['sparsified_seq_lens'],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        layer_idx=layer_idx_buffer, # a 0-D tensors
+        num_layers=num_layers,
+        page_block_size=data['page_block_size'],
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        use_triton=False,
+        add_layer_idx_by_one_after_run=True
+    )
+    for layer_idx in range(num_layers):
+        output_per_head, lse_per_head = batch_attention_wrapper.run(
+            data['query'], (data['key'], data['value'])
+        )
+        output_ours.append(output_per_head)
+        lse_ours.append(lse_per_head)
+
+    # check correctness
+    for layer_idx in range(num_layers):
+        torch.testing.assert_close(output_golden[layer_idx], output_ours[layer_idx], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(lse_golden[layer_idx], lse_ours[layer_idx], rtol=1e-3, atol=1e-3)
+
+@pytest.mark.parametrize("num_layers", [2, 8, 16, 32])
+def test_per_layer_correctness_with_cuda_graph(num_layers, device="cuda"):
+    """Test whether the layer_idx is correctly updated with CUDA graph"""
+    # -------------------------  test hyper-params  ------------------------- #
+    seed = 42
+    batch_size = 4
+    num_kv_heads = 4
+    num_qo_heads = 32
+    head_dim = 128
+    causal = True
+    dtype = torch.bfloat16
+    min_seq_len = 100
+    max_seq_len = 500
+    min_q_len = 1
+    max_q_len = 50
+
+    data = generate_test_data(
+        batch_size, num_kv_heads, num_qo_heads, head_dim,
+        device, dtype, seed,
+        min_seq_len=min_seq_len, max_seq_len=max_seq_len,
+        min_q_len=min_q_len, max_q_len=max_q_len, num_layers=num_layers
+    )
+
+    # golden, plan once, no cuda graph
+    output_no_cuda_graph, lse_no_cuda_graph = [], []
+    batch_attention_wrapper = flashinfer.BatchAttentionWithPerHeadSelectPagedKVCacheWrapper(device=device)
+    layer_idx_buffer = torch.tensor([0], device=device)
+    batch_attention_wrapper.plan(
+        qo_indptr=data['qo_indptr'],
+        kv_indptr=data['kv_indptr'],
+        all_layers_per_head_kv_indices=data['all_layers_per_head_kv_indices'].int(), # (num_layers, num_kv_heads, total_kv_indices)
+        seq_lens=data['sparsified_seq_lens'],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        layer_idx=layer_idx_buffer, # a 0-D tensors
+        num_layers=num_layers,
+        page_block_size=data['page_block_size'],
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        use_triton=False,
+        add_layer_idx_by_one_after_run=True
+    )
+    for layer_idx in range(num_layers):
+        output_per_head, lse_per_head = batch_attention_wrapper.run(
+            data['query'], (data['key'], data['value'])
+        )
+        output_no_cuda_graph.append(output_per_head)
+        lse_no_cuda_graph.append(lse_per_head)
+
+    torch.cuda.synchronize()
+
+    #===============================================
+
+    # reference, plan once, with cuda graph
+    batch_attention_wrapper_cg = flashinfer.BatchAttentionWithPerHeadSelectPagedKVCacheWrapper(device=device)
+    layer_idx_buffer_cg = torch.tensor([0], device=device)
+    batch_attention_wrapper_cg.plan(
+        qo_indptr=data['qo_indptr'],
+        kv_indptr=data['kv_indptr'],
+        all_layers_per_head_kv_indices=data['all_layers_per_head_kv_indices'].int(), # (num_layers, num_kv_heads, total_kv_indices)
+        seq_lens=data['sparsified_seq_lens'],
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim_qk=head_dim,
+        head_dim_vo=head_dim,
+        layer_idx=layer_idx_buffer_cg, # a 0-D tensors
+        num_layers=num_layers,
+        page_block_size=data['page_block_size'],
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        use_triton=False,
+        add_layer_idx_by_one_after_run=True
+    )
+
+    # warm-up in a side stream
+    warm_stream = torch.cuda.Stream()
+    warm_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warm_stream):
+        for _ in range(3):
+            layer_idx_buffer_cg.zero_()
+            for _ in range(num_layers):
+                batch_attention_wrapper_cg.run(data["query"], (data["key"], data["value"]))
+    torch.cuda.current_stream().wait_stream(warm_stream)
+
+    # allocate placeholder tensors that will *receive* results during capture
+    cap_outputs = [torch.empty_like(output_no_cuda_graph[0]) for _ in range(num_layers)]
+    cap_lses    = [torch.empty_like(lse_no_cuda_graph[0])    for _ in range(num_layers)]
+
+    capture_graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(capture_graph):
+        layer_idx_buffer_cg.zero_()
+        for i in range(num_layers):
+            o, l = batch_attention_wrapper_cg.run(data["query"], (data["key"], data["value"]))
+            cap_outputs[i].copy_(o)
+            cap_lses[i].copy_(l)
+
+    capture_graph.replay()
+    torch.cuda.synchronize()
+
+    # ------------------------- assertions ------------------------- #
+    for i in range(num_layers):
+        assert torch.allclose(
+            output_no_cuda_graph[i], cap_outputs[i], rtol=2e-2, atol=2e-2
+        ), f"output mismatch at layer {i}"
+        assert torch.allclose(
+            lse_no_cuda_graph[i], cap_lses[i], rtol=1e-3, atol=1e-3
+        ), f"LSE mismatch at layer {i}"
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

### Overview
This PR introduces support for per-head-per-layer KV indices in BatchAttention, enabling fine-grained control over which KV cache entries each attention head accesses, given that the kv_indptr could be shared.

#### Example
```python
# KV indices shape: (num_layers, num_kv_heads, total_kv_indices)
kv_indices = torch.tensor([
    # Layer 0
    [[0, 1, 2], [1, 2, 3], ...],  # Head 0, Head 1, ...
    # Layer 1
    [[0, 2, 3], [0, 1, 3], ...],  # Head 0, Head 1, ...
    ...
])

# Shared indptr for all heads and layers (Same as before)
kv_indptr = torch.tensor([0, 3, 6, ...]).
```
With this PR, we can not support the fine-grained KV loading in attention computation. 


Please check the testing scripts for more details.
```
python tests/test_per_head_kv_batch_attention.py
```


## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes
The description below is the logic behind how I handle the inidce for per-head cases.  (For Yilong)

### Head-Major Organization

Virtual batches are organized in head-first order:
```
Virtual batch 0: (real_batch_0, kv_head_0)
Virtual batch 1: (real_batch_1, kv_head_0)
Virtual batch 2: (real_batch_2, kv_head_0)
Virtual batch 3: (real_batch_0, kv_head_1)
Virtual batch 4: (real_batch_1, kv_head_1)
Virtual batch 5: (real_batch_2, kv_head_1)
```

This organization ensures all batches for a given head are processed contiguously.

### Query Transformation Logic

Each batch can have multiple query tokens.

**Input**: `query` shape `(total_query_tokens, num_qo_heads, head_dim)`

**Virtual qo_indptr Construction**:
```python
# Example: batch_size=2, num_kv_heads=3
# Original qo_indptr: [0, 5, 8] (batch 0: 5 tokens, batch 1: 3 tokens)
# Virtual qo_indptr:  [0, 5, 8, 13, 16, 21, 24]
#                     ^head0^ ^-head1-^ ^-head2-^

# Optimized implementation (22% faster with in-place cumsum)
qo_lengths = qo_indptr[1:] - qo_indptr[:-1]
qo_lengths_repeated = qo_lengths.repeat(num_kv_heads)
virtual_qo_indptr = torch.zeros(batch_size * num_kv_heads + 1, dtype=torch.int32)
virtual_qo_indptr[1:] = qo_lengths_repeated
torch.cumsum(virtual_qo_indptr, dim=0, out=virtual_qo_indptr)
```

**Query Transformation**:
```python
# Simple 3-line transformation
query_reshaped = query.view(total_query_tokens, num_kv_heads, gqa_group_size, head_dim)
query_permuted = query_reshaped.permute(1, 0, 2, 3)
query_for_flashinfer = query_permuted.reshape(-1, gqa_group_size, head_dim)
```
> Practically, we implement this using `einops`.

### Key/Value Index Transformation

#### KV Cache Layout

FlashInfer uses interleaved layout: `(total_blocks, page_size, num_heads, head_dim)`

**KV Cache Reshaping**:
```python
# Treat each head as having num_kv_heads=1
key_reshaped = key.view(total_blocks * num_kv_heads, page_block_size, 1, head_dim)
value_reshaped = value.view(total_blocks * num_kv_heads, page_block_size, 1, head_dim)
```

##### Index Augmentation

**Augmentation Formula**: `augmented_idx = original_block_idx * num_kv_heads + head_idx`

**Example**:
- Original block index 5 for head 2 with 4 heads
- Augmented index: 5 × 4 + 2 = 22
- This maps to the correct position in the reshaped KV cache

##### Output Offsets (Virtual KV Batch Boundaries)

```python
# Example: batch_size=3, num_kv_heads=3
# Original kv_indptr: [0, 10, 18, 25] (batch sizes: 10, 8, 7)
# Output offsets:     [0, 10, 18, 25, 35, 43, 50, 60, 68, 75]
#                     ^---head0---^ ^---head1---^ ^---head2---^

# Optimized implementation
kv_batch_lengths = kv_indptr[1:] - kv_indptr[:-1]
kv_batch_lengths_repeated = kv_batch_lengths.repeat(num_kv_heads)
output_offsets = torch.zeros(batch_size * num_kv_heads + 1, dtype=torch.int32)
output_offsets[1:] = kv_batch_lengths_repeated
torch.cumsum(output_offsets, dim=0, out=output_offsets)
```

#### Output Reconstruction

After attention computation, outputs need to be transformed back from head-major to batch-major order.

```python
# Input: (num_kv_heads * total_query_tokens, gqa_group_size, head_dim)
# Output: (total_query_tokens, num_qo_heads, head_dim)

output_reshaped = output.view(num_kv_heads, total_query_tokens, gqa_group_size, head_dim)
output_permuted = output_reshaped.permute(1, 0, 2, 3)
output_final = output_permuted.reshape(total_query_tokens, num_qo_heads, head_dim)
```